### PR TITLE
fix mock address in tests

### DIFF
--- a/pkg/client/client_test.go
+++ b/pkg/client/client_test.go
@@ -155,6 +155,7 @@ func newTestClient(xInst runnable, tun io.ReadWriteCloser, routes ipTable, pipe 
 		routes:        routes,
 		pipe:          pipe,
 		xCfg:          expGeneralConfig,
+		xSrvIP:        &net.IPAddr{IP: net.ParseIP("127.0.0.3")},
 	}
 	if stopTunnel != nil {
 		cl.stopTunnel = func() {


### PR DESCRIPTION
This fixes tests. Previously, I was getting this error:

```
time=2025-12-23T11:13:10.098Z level=ERROR msg="xray core creation failed" err="invalid config: protocol create: invalid xray protocol" xray_config=<nil>
time=2025-12-23T11:13:10.098Z level=ERROR msg="xray core creation failed" err="invalid config: parse: failed to split host and port for VLESS link: address example.com: missing port in address" xray_config=<nil>
--- FAIL: TestDisconnect_CtxTimeout (0.00s)
    --- FAIL: TestDisconnect_CtxTimeout/ok (0.00s)
        controller.go:97: missing call(s) to *mocks.MockipTable.Delete(is anything) /build/source/pkg/client/client_test.go:171
        controller.go:97: aborting test due to missing call(s)
panic: parse cidr: invalid CIDR address: <nil>/32 [recovered, repanicked]

goroutine 18 [running]:
testing.tRunner.func1.2({0x132afe0, 0xc00035a1e0})
        /nix/store/k1kn1c59ss7nq6agdppzq3krwmi3xqy4-go-1.25.2/share/go/src/testing/testing.go:1872 +0x237
testing.tRunner.func1()
        /nix/store/k1kn1c59ss7nq6agdppzq3krwmi3xqy4-go-1.25.2/share/go/src/testing/testing.go:1875 +0x35b
panic({0x132afe0?, 0xc00035a1e0?})
        /nix/store/k1kn1c59ss7nq6agdppzq3krwmi3xqy4-go-1.25.2/share/go/src/runtime/panic.go:783 +0x132
github.com/goxray/core/network/route.MustParseAddr(...)
        /build/source/vendor/github.com/goxray/core/network/route/addr.go:42
github.com/goxray/tun/pkg/client.(*Client).xrayToGatewayRoute(0xc0002764d0)
        /build/source/pkg/client/client.go:299 +0x12a
github.com/goxray/tun/pkg/client.(*Client).Disconnect(0xc0002764d0, {0x175bdc8, 0x224d3a0})
        /build/source/pkg/client/client.go:254 +0xd0
github.com/goxray/tun/pkg/client.TestDisconnect_CtxTimeout.func3({0x175bdc8?, 0x224d3a0?}, 0x989680?, 0xc00020da40)
        /build/source/pkg/client/client_test.go:59 +0x29
github.com/goxray/tun/pkg/client.TestDisconnect_CtxTimeout.func16(0xc00020da40)
        /build/source/pkg/client/client_test.go:136 +0x35a
testing.tRunner(0xc00020da40, 0xc00032ac90)
        /nix/store/k1kn1c59ss7nq6agdppzq3krwmi3xqy4-go-1.25.2/share/go/src/testing/testing.go:1934 +0xea
created by testing.(*T).Run in goroutine 16
        /nix/store/k1kn1c59ss7nq6agdppzq3krwmi3xqy4-go-1.25.2/share/go/src/testing/testing.go:1997 +0x465
FAIL    github.com/goxray/tun/pkg/client        0.009s
FAIL
```