### PR TITLE
Security hardening and installation examples

### DIFF
--- a/extras/etc/README.md
+++ b/extras/etc/README.md
@@ -2,19 +2,19 @@
 We'll add user to run the binary in separate environment and set up permissions. The process does not read the secrets file, systemd does, but we'll add owner for clarity.
 ```sh
 $ sudo useradd --system xray
-$ sudo install -d -m 700 -o xray -g xray /etc/goxray/
-$ sudo install -m 644 -o root -g root extras/etc/goxray/template1.env /etc/goxray/  # edit template1.env with your vless url
+$ sudo install -d -m 700 -o root -g xray /etc/goxray/
+$ sudo install -m 640 -o root -g xray extras/etc/goxray/template1.env /etc/goxray/  # edit template1.env with your vless url
 ```
 
 ## Installing systemd unit
-With this parameterized systemd unit we can hold multiple xray configurations and enable/disable them as needed. Notice `template1` name as a parameter, without the `.env` extension.
+With this parameterized systemd unit we can hold multiple xray configurations and enable/disable them as needed. Notice `template1` name as a parameter, without the `.env` extension. Expects the binary to be located at `/usr/local/bin/goxray_cli_linux_amd64` path.
 ```
 $ sudo install -m 644 -o root -g root extras/etc/systemd/system/goxray_cli@.service /etc/systemd/system/
 $ sudo systemctl enable goxray_cli@template1.service
 ```
 
 ## Installing AppArmor profile
-This allowes to run the binary only with required access, operationg on [MAC](https://en.wikipedia.org/wiki/Mandatory_access_control) principles. Protection is only active when executable is located at `@{exec_path}` paths. Written for latest Debian/Ubuntu.
+This allowes to run the binary only with required access, operationg on [MAC](https://en.wikipedia.org/wiki/Mandatory_access_control) principles. AppArmor protection is only active when executable is located at `@{exec_path}` paths. Written for latest Debian/Ubuntu.
 ```sh
 $ sudo install -m 644 -o root -g root extras/etc/apparmor.d/goxray_cli /etc/apparmor.d/  # install AppArmor profile for executable
 $ sudo apparmor_parser --add /etc/apparmor.d/goxray_cli                                  # confine profile for executable

--- a/extras/etc/README.md
+++ b/extras/etc/README.md
@@ -14,7 +14,7 @@ $ sudo systemctl enable goxray_cli@template1.service
 ```
 
 ## Installing AppArmor profile
-This allowes to run the binary only with required access, operationg on [MAC](https://en.wikipedia.org/wiki/Mandatory_access_control) principles. AppArmor protection is only active when executable is located at `@{exec_path}` paths. Written for latest Debian/Ubuntu.
+This allowes to run the binary only with required access, operating on [MAC](https://en.wikipedia.org/wiki/Mandatory_access_control) principles. AppArmor protection is only active when executable is located at `@{exec_path}` paths. Written for latest Debian/Ubuntu.
 ```sh
 $ sudo install -m 644 -o root -g root extras/etc/apparmor.d/goxray_cli /etc/apparmor.d/  # install AppArmor profile for executable
 $ sudo apparmor_parser --add /etc/apparmor.d/goxray_cli                                  # confine profile for executable

--- a/extras/etc/README.md
+++ b/extras/etc/README.md
@@ -1,5 +1,5 @@
 ## Setting up secrets directory
-We'll add user to run the binary and set up permissions. The process does not read the secrets file, systemd does, but we'll add owner for clarity.
+We'll add user to run the binary in separate environment and set up permissions. The process does not read the secrets file, systemd does, but we'll add owner for clarity.
 ```sh
 $ sudo useradd --system xray
 $ sudo install -d -m 700 -o xray -g xray /etc/goxray/
@@ -7,14 +7,14 @@ $ sudo install -m 644 -o root -g root extras/etc/goxray/template1.env /etc/goxra
 ```
 
 ## Installing systemd unit
-With this parameterized systemd unit we can hold multiple xray configurations and enable/disable them as needed.
+With this parameterized systemd unit we can hold multiple xray configurations and enable/disable them as needed. Notice `template1` name as a parameter, without the `.env` extension.
 ```
 $ sudo install -m 644 -o root -g root extras/etc/systemd/system/goxray_cli@.service /etc/systemd/system/
 $ sudo systemctl enable goxray_cli@template1.service
 ```
 
 ## Installing AppArmor profile
-This allowes to run the binary only with needed access, operationg on [MAC](https://en.wikipedia.org/wiki/Mandatory_access_control) principles. Written for latest Debian/Ubuntu.
+This allowes to run the binary only with required access, operationg on [MAC](https://en.wikipedia.org/wiki/Mandatory_access_control) principles. Written for latest Debian/Ubuntu.
 ```sh
 $ sudo install -m 644 -o root -g root extras/etc/apparmor.d/goxray_cli /etc/apparmor.d/  # install AppArmor profile for executable
 $ sudo apparmor_parser --add /etc/apparmor.d/goxray_cli                                  # confine profile for executable

--- a/extras/etc/README.md
+++ b/extras/etc/README.md
@@ -14,7 +14,7 @@ $ sudo systemctl enable goxray_cli@template1.service
 ```
 
 ## Installing AppArmor profile
-This allowes to run the binary only with required access, operationg on [MAC](https://en.wikipedia.org/wiki/Mandatory_access_control) principles. Written for latest Debian/Ubuntu.
+This allowes to run the binary only with required access, operationg on [MAC](https://en.wikipedia.org/wiki/Mandatory_access_control) principles. Protection is only active when executable is located at `@{exec_path}` paths. Written for latest Debian/Ubuntu.
 ```sh
 $ sudo install -m 644 -o root -g root extras/etc/apparmor.d/goxray_cli /etc/apparmor.d/  # install AppArmor profile for executable
 $ sudo apparmor_parser --add /etc/apparmor.d/goxray_cli                                  # confine profile for executable

--- a/extras/etc/README.md
+++ b/extras/etc/README.md
@@ -1,0 +1,21 @@
+## Setting up secrets directory
+We'll add user to run the binary and set up permissions. The process does not read the secrets file, systemd does, but we'll add owner for clarity.
+```sh
+$ sudo useradd --system xray
+$ sudo install -d -m 700 -o xray -g xray /etc/goxray/
+$ sudo install -m 644 -o root -g root extras/etc/goxray/template1.env /etc/goxray/  # edit template1.env with your vless url
+```
+
+## Installing systemd unit
+With this parameterized systemd unit we can hold multiple xray configurations and enable/disable them as needed.
+```
+$ sudo install -m 644 -o root -g root extras/etc/systemd/system/goxray_cli@.service /etc/systemd/system/
+$ sudo systemctl enable goxray_cli@template1.service
+```
+
+## Installing AppArmor profile
+This allowes to run the binary only with needed access, operationg on [MAC](https://en.wikipedia.org/wiki/Mandatory_access_control) principles. Written for latest Debian/Ubuntu.
+```sh
+$ sudo install -m 644 -o root -g root extras/etc/apparmor.d/goxray_cli /etc/apparmor.d/  # install AppArmor profile for executable
+$ sudo apparmor_parser --add /etc/apparmor.d/goxray_cli                                  # confine profile for executable
+```

--- a/extras/etc/apparmor.d/goxray_cli
+++ b/extras/etc/apparmor.d/goxray_cli
@@ -1,0 +1,33 @@
+# apparmor.d - Full set of apparmor profiles
+# SPDX-License-Identifier: GPL-2.0-only
+
+abi <abi/3.0>,
+
+include <tunables/global>
+
+@{exec_path} = /{,usr/}{,local/}bin/goxray_cli /{,usr/}{,local/}bin/goxray_cli_linux_amd64 /{,usr/}{,local/}bin/goxray_cli_linux_arm64
+profile goxray_cli @{exec_path} {
+  include <abstractions/base>
+  include <abstractions/consoles>
+  include <abstractions/openssl>
+  include <abstractions/ssl_certs>
+  include <abstractions/nameservice-strict>
+
+  # Operate TUN interfaces
+  capability net_admin,
+
+  network inet dgram,
+  network inet6 dgram,
+  network inet stream,
+  network inet6 stream,
+  network netlink raw,
+
+  @{exec_path} r,
+
+  @{PROC}/@{pid}/net/route r,
+  @{PROC}/sys/net/core/somaxconn r,
+
+  /dev/net/tun rw,
+
+  include if exists <local/goxray_cli>
+}

--- a/extras/etc/goxray/template1.env
+++ b/extras/etc/goxray/template1.env
@@ -1,0 +1,1 @@
+GOXRAY_CONFIG_URL='vless://your_secret_url'

--- a/extras/etc/systemd/system/goxray_cli@.service
+++ b/extras/etc/systemd/system/goxray_cli@.service
@@ -1,0 +1,28 @@
+[Unit]
+Description=goxray_cli VPN service for %i
+After=network.target
+
+[Service]
+Type=simple
+EnvironmentFile=/etc/goxray/%i.env
+ExecStart=/usr/local/bin/goxray_cli_linux_amd64
+User=xray
+Group=xray
+CapabilityBoundingSet=CAP_NET_ADMIN
+AmbientCapabilities=CAP_NET_ADMIN
+NoNewPrivileges=yes
+PrivateTmp=yes
+ProtectHome=read-only
+ProtectControlGroups=yes
+ProtectKernelModules=yes
+ProtectKernelTunables=yes
+RestrictAddressFamilies=AF_INET AF_INET6 AF_NETLINK
+RestrictNamespaces=yes
+RestrictRealtime=yes
+RestrictSUIDSGID=yes
+MemoryDenyWriteExecute=yes
+LockPersonality=yes
+Restart=on-failure
+
+[Install]
+WantedBy=multi-user.target


### PR DESCRIPTION
I've managed to run the binary with only `CAP_NET_ADMIN`, elevated with systemd, so no `setcap` were necessary. `cap_net_bind_service` is only needed with lower port? And `cap_net_raw`? Neither showed on my debugging log.

Integrate in base readme as you see fit.